### PR TITLE
Fix comma key highlight

### DIFF
--- a/draw_piano.py
+++ b/draw_piano.py
@@ -218,6 +218,8 @@ class PianoKeyboard(Gtk.DrawingArea):
             return
         octave_number = 0
         changed_key = None
+        if key_letter == ',':
+            key_letter = 'Q'
         for values in self._values:
             if values.find(key_letter) > -1:
                 key_number = values.find(key_letter)


### PR DESCRIPTION
The comma key (,) is an alias for the Q key, but does not highlight the
piano key on the display.

At the critical point, intercept the comma key and change it to a Q key.