### PR TITLE
Try to fix stuck notes

### DIFF
--- a/draw_piano.py
+++ b/draw_piano.py
@@ -138,7 +138,8 @@ class PianoKeyboard(Gtk.DrawingArea):
                 updated_positions = True
             elif event.type in (
                     Gdk.EventType.TOUCH_END, Gdk.EventType.BUTTON_RELEASE):
-                del self._touches[seq]
+                if seq in self._touches:
+                    del self._touches[seq]
                 # execute the update pressed keys with a delay,
                 # because motion events can came after the button release
                 # and all the state is confused


### PR DESCRIPTION
Occasionally a note will stick.  The note on screen stays yellow.  Sound persists.  Clicking or touching the note doesn't clear it.  Other notes respond properly.

Activity log shows:
```
Traceback (most recent call last):
  File "/usr/share/sugar/activities/MusicKeyboard.activity/draw_piano.py", line 141, in __event_cb
    del self._touches[seq]
KeyError: '<Gdk.EventSequence object at 0x7f44d80afce8 (GdkEventSequence at 0x137c240)>'
```
When `__event_cb` hits this exception, the remaining code in the method, in particular updating pressed keys, is bypassed.

Patch changes the code to avoid the error.

This is very hard to reproduce, but one method is to have the activity running and idle, then use the computer for a large task such as downloading and installing packages.